### PR TITLE
Fido2: Support for user handles

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -31,6 +31,7 @@ class WrongPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
 class UserInfo(
+    val handle: ByteArray? = null,
     val name: String,
     val displayName: String? = null,
     val icon: String? = null

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -528,13 +528,14 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         val assertionResponses = ArrayList<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>>()
 
         for ((response, credentialId) in responses) {
+            val handle = response.user?.id
             var name = response.user?.name
             var displayName = response.user?.displayName
             var icon = response.user?.icon
 
             var userInfo: UserInfo? = null
             if (name != null) {
-                userInfo = UserInfo(name, displayName, icon)
+                userInfo = UserInfo(handle, name, displayName, icon)
             }
 
             val assertionResponse = AuthenticatorAssertionResponse(
@@ -542,7 +543,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                 clientData,
                 response.authData,
                 response.signature,
-                null
+                handle
             )
             assertionResponses.add(userInfo to suspend { assertionResponse })
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
@@ -144,11 +144,12 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
             store.getPublicKey(options.rpId, keyId)
                 ?: throw RequestHandlingException(ErrorCode.INVALID_STATE_ERR)
 
+        val handle = options.registerOptions.user.id
         val name = options.registerOptions.user.name
         val displayName = options.registerOptions.user.displayName
         val icon = options.registerOptions.user.icon
 
-        store.addUserInfo(options.rpId, keyId, name, displayName, icon)
+        store.addUserInfo(options.rpId, keyId, handle, name, displayName, icon)
 
         // We're ignoring the signature object as we don't need it for registration
         val signature = getActiveSignature(options, callerPackage, keyId)
@@ -283,7 +284,7 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
                     clientData,
                     authenticatorData.encode(),
                     sig,
-                    null
+                    userInfo?.handle
                 )
             }
 


### PR DESCRIPTION
Some website require having the user handle, for example passkeys.io

This commit adds this support

PS: I'll use yours patches for the credential selection to [HW Fdo2 Provider](https://codeberg.org/s1m/hw-fido2-provider)